### PR TITLE
Fix the size of predicted trajectories during evaluation

### DIFF
--- a/tools/eval_utils/eval_utils.py
+++ b/tools/eval_utils/eval_utils.py
@@ -61,7 +61,7 @@ def eval_one_epoch(cfg, model, dataloader, epoch_id, logger, dist_test=False, sa
         progress_bar.close()
 
     if dist_test:
-        pred_dicts = common_utils.merge_results_dist(pred_dicts, len(dataset), tmpdir=result_dir / 'tmpdir')
+        pred_dicts = common_utils.merge_results_dist(pred_dicts, np.iinfo(np.int32).max, tmpdir=result_dir / 'tmpdir')
 
     logger.info('*************** Performance of EPOCH %s *****************' % epoch_id)
     sec_per_example = (time.time() - start_time) / len(dataloader.dataset)


### PR DESCRIPTION
The `len(dataset)` input to the `merge_results_dist` function incorrectly restricts the size of the merged `pred_dicts`. It should be equal to the total number of trajectories (center objects) in the validation set, as each element in `pred_dicts` corresponds to a single trajectory. However, using `len(dataset)` actually represents the **number of scenarios**, which is significantly smaller than the **number of center objects**.

In practice, we have observed that the original code consistently saves the results of 40,097 trajectories in the `result.pkl` file, where 40,097 is the number of scenarios in the validation set. Nevertheless, we should ideally have 192,172 trajectories accounted for for the validation set. This discrepancy results in the effective validation of smaller prediction outcomes.

